### PR TITLE
allow cloud-config to work on distros with read-only /usr partitions

### DIFF
--- a/commands/create.go
+++ b/commands/create.go
@@ -453,6 +453,10 @@ func writeCloudConfig(machineName, encodedData, machineOS, hostname string, cf m
 	command := "sh"
 	path := "/usr/local/custom_script/install.sh"
 	key := "hostname"
+	// allow the script to work on distros with read-only /usr partitions
+	if strings.Contains(machineOS, "coreos") || strings.Contains(machineOS, "coreos") {
+		path = "/var/run/install.sh"
+	}
 	if strings.Contains(machineOS, "windows") {
 		// the writeFile path should ideally be C:\usr\local\custom_script\install.ps1
 		// however, we can't guarantee that directory exists or can be created on the target machine


### PR DESCRIPTION
As title.